### PR TITLE
Fix hushd to work when called via symlink

### DIFF
--- a/src/hushd
+++ b/src/hushd
@@ -2,7 +2,7 @@
 # Copyright (c) 2019 Hush developers
 
 # set working directory to the location of this script
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR="$( cd "$( dirname "$( readlink -f "${BASH_SOURCE[0]}" )" )" && pwd )"
 cd $DIR
 
 NAME=HUSH3


### PR DESCRIPTION
If you symlink `hushd` to `/usr/local/bin` and then call `hushd`, `dirname "${BASH_SOURCE[0]}"` will resolve to the symlinked DIR (`/usr/local/bin`).

That means inside the script `./komodod` will resolve to `/usr/local/bin/komodod` which will likely be upstream `komodod` not the HUSH3 fork of `komodod`.