### PR TITLE
Make the order of zaddr recipients we give to z_sendmany internals non-deterministic

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4543,17 +4543,27 @@ UniValue z_sendmany(const UniValue& params, bool fHelp, const CPubKey& mypk)
 
         string zdust1, zdust2;
 
-        // Which zaddr we send to is non-deterministically chosen...
+        // Which zaddr we send to is non-deterministically chosen from two zpools...
         zdust1 = randomSietchZaddr();
 
-	    zaddrRecipients.push_back( SendManyRecipient(zdust1, nAmount, memo) );
+        // And their ordering when given to internals is also non-deterministic, which
+        // helps breaks assumptions blockchain analysts may use from z_sendmany internals
+        if (decider % 2) {
+	        zaddrRecipients.insert(std::begin(zaddrRecipients), SendManyRecipient(zdust1, nAmount, memo) );
+        } else {
+	        zaddrRecipients.push_back( SendManyRecipient(zdust1, nAmount, memo) );
+        }
         if(fZdebug)
             fprintf(stderr,"%s: adding %s as zdust receiver\n", __FUNCTION__, zdust1.c_str());
 
         //50% chance of adding another zout
         if (decider % 2) {
             zdust2 = randomSietchZaddr();
-            zaddrRecipients.push_back( SendManyRecipient(zdust2, nAmount, memo) );
+            if(decider % 4 == 3) {
+                zaddrRecipients.push_back( SendManyRecipient(zdust2, nAmount, memo) );
+            } else {
+                zaddrRecipients.insert(std::begin(zaddrRecipients), SendManyRecipient(zdust2, nAmount, memo) );
+            }
             if(fZdebug)
                 fprintf(stderr,"%s: adding %s as zdust receiver\n", __FUNCTION__, zdust2.c_str());
         }


### PR DESCRIPTION
The author has noticed that Zcash internals preserves too much order of datastructures that could leak metadata, so this mitigation makes it difficult to predict which zout(s) was/were the original receiver(s)