### PR TITLE
Port aarch64 stuff from @radix42

### DIFF
--- a/depends/packages/rust.mk
+++ b/depends/packages/rust.mk
@@ -1,24 +1,12 @@
 package=rust
-$(package)_version=1.32.0
+$(package)_version=1.28.0
 $(package)_download_path=https://static.rust-lang.org/dist
-
-$(package)_file_name_linux=rust-$($(package)_version)-x86_64-unknown-linux-gnu.tar.gz
-$(package)_sha256_hash_linux=e024698320d76b74daf0e6e71be3681a1e7923122e3ebd03673fcac3ecc23810
+$(package)_file_name_linux=rust-$($(package)_version)-aarch64-unknown-linux-gnu.tar.gz
+$(package)_sha256_hash_linux=9b6fbcee73070332c811c0ddff399fa31965bec62ef258656c0c90354f6231c1
 $(package)_file_name_darwin=rust-$($(package)_version)-x86_64-apple-darwin.tar.gz
-$(package)_sha256_hash_darwin=f0dfba507192f9b5c330b5984ba71d57d434475f3d62bd44a39201e36fa76304
+$(package)_sha256_hash_darwin=5d7a70ed4701fe9410041c1eea025c95cad97e5b3d8acc46426f9ac4f9f02393
 $(package)_file_name_mingw32=rust-$($(package)_version)-x86_64-pc-windows-gnu.tar.gz
-$(package)_sha256_hash_mingw32=358e1435347c67dbf33aa9cad6fe501a833d6633ed5d5aa1863d5dffa0349be9
-
-ifeq ($(build_os),darwin)
-$(package)_file_name=$($(package)_file_name_darwin)
-$(package)_sha256_hash=$($(package)_sha256_hash_darwin)
-else ifeq ($(host_os),mingw32)
-$(package)_file_name=$($(package)_file_name_mingw32)
-$(package)_sha256_hash=$($(package)_sha256_hash_mingw32)
-else
-$(package)_file_name=$($(package)_file_name_linux)
-$(package)_sha256_hash=$($(package)_sha256_hash_linux)
-endif
+$(package)_sha256_hash_mingw32=55c07426f791c51c8a2b6934b35784175c4abb4e03f123f3e847109c4dc1ad8b
 
 ifeq ($(host_os),mingw32)
 $(package)_build_subdir=buildos

--- a/src/cc/makerogue
+++ b/src/cc/makerogue
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Copyright (c) 2019-2020 The Hush developers
+
 cd rogue;
 make clean;
 
@@ -19,7 +21,7 @@ if [ "$HOST" = "x86_64-w64-mingw32" ]; then
   fi
 else
   echo building rogue...
-  ./configure
+  ./configure --build=aarch64-unknown-linux-gnu
   if make "$@"; then
     echo rogue build SUCCESSFUL
     cd ..

--- a/src/komodo_curve25519.h
+++ b/src/komodo_curve25519.h
@@ -1,3 +1,4 @@
+// Copyright (c) 2019-2020 The Hush developers
 /******************************************************************************
  * Copyright © 2014-2019 The SuperNET Developers.                             *
  *                                                                            *
@@ -81,7 +82,7 @@ bits320 fexpand(bits256 basepoint)
     return(out);
 }
 
-#if __amd64__
+//#if __amd64__
 // donna: special gcc mode for 128-bit integers. It's implemented on 64-bit platforms only as far as I know.
 typedef unsigned uint128_t __attribute__((mode(TI)));
 
@@ -1010,4 +1011,4 @@ int32_t komodo_kvsigverify(uint8_t *buf,int32_t len,uint256 _pubkey,uint256 sig)
     return(0);
 }
 
-#endif
+//#endif

--- a/zcutil/build-arm.sh
+++ b/zcutil/build-arm.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Copyright (c) 2019-2020 The Hush developers
+# Original aarch64 port by radix42. Thank you!
+
+set -eu -o pipefail
+
+cat <<'EOF'
+ ________________
+< Building Hush! >
+ ----------------
+        \   ^__^
+         \  (oo)\_______
+            (__)\       )\/\
+                ||----w |
+                ||     ||
+EOF
+
+if [ "x$*" = 'x--help' ]
+then
+    cat ./zcutil/dragon.txt
+    cat <<EOF
+Welcome To The Hush Build System, Here Be Dragons!
+Usage:
+$0 --help
+  Show this help message and exit.
+$0 [ --enable-lcov ] [ MAKEARGS... ]
+  Build Hush and most of its transitive dependencies from
+  source. MAKEARGS are applied to both dependencies and Hush itself. If
+  --enable-lcov is passed, Hush is configured to add coverage
+  instrumentation, thus enabling "make cov" to work.
+EOF
+    exit 0
+fi
+
+set -x
+cd "$(dirname "$(readlink -f "$0")")/.."
+
+# If --enable-lcov is the first argument, enable lcov coverage support:
+LCOV_ARG=''
+HARDENING_ARG='--disable-hardening'
+if [ "x${1:-}" = 'x--enable-lcov' ]
+then
+    LCOV_ARG='--enable-lcov'
+    HARDENING_ARG='--disable-hardening'
+    shift
+fi
+
+# BUG: parameterize the platform/host directory:
+PREFIX="$(pwd)/depends/aarch64-unknown-linux-gnu/"
+
+HOST=aarch64-unknown-linux-gnu BUILD=aarch64-unknown-linux-gnu make "$@" -C ./depends/ V=1 NO_QT=1
+./autogen.sh
+CONFIG_SITE="$(pwd)/depends/aarch64-unknown-linux-gnu/share/config.site" ./configure --prefix="${PREFIX}" --host=aarch64-unknown-linux-gnu --build=aarch64-unknown-linux-gnu --with-gui=no --enable-rust=no --disable-proton "$HARDENING_ARG" "$LCOV_ARG" CXXFLAGS='-fwrapv -fno-strict-aliasing -g'
+
+#BUILD CCLIB
+
+WD=$PWD
+cd src/cc
+echo $PWD
+./makecustom
+cd $WD
+
+make "$@" V=1


### PR DESCRIPTION
I ported the remaining things to deal with from this branch:

https://github.com/MercerWeissAlt/komodo/tree/dev-aarch64

Since we deleted libsnark and verushash, many things were already done. This still needs testing.