### PR TITLE
Untested sapling consolidation plus sietch outputs to reduce metadata leakage

### DIFF
--- a/src/komodo_bitcoind.h
+++ b/src/komodo_bitcoind.h
@@ -24,6 +24,7 @@
 #include "komodo_defs.h"
 #include "script/standard.h"
 #include "cc/CCinclude.h"
+#include "sietch.h"
 
 int32_t komodo_notaries(uint8_t pubkeys[64][33],int32_t height,uint32_t timestamp);
 int32_t komodo_electednotary(int32_t *numnotariesp,uint8_t *pubkey33,int32_t height,uint32_t timestamp);

--- a/src/wallet/asyncrpcoperation_saplingconsolidation.cpp
+++ b/src/wallet/asyncrpcoperation_saplingconsolidation.cpp
@@ -120,7 +120,10 @@ bool AsyncRPCOperation_saplingconsolidation::main_impl() {
 
             std::vector<SaplingNoteEntry> fromNotes;
             CAmount amountToSend = 0;
-            int maxQuantity = rand() % 35 + 10;
+            // max of 8 zins means the tx cannot reduce the anonset,
+            // since there will be 8 zins and 8 zouts at worst case
+            // This also helps reduce ztx creation time
+            int maxQuantity = rand() % 8 + 1;
             for (const SaplingNoteEntry& saplingEntry : saplingEntries) {
 
                 libzcash::SaplingIncomingViewingKey ivk;
@@ -132,14 +135,16 @@ bool AsyncRPCOperation_saplingconsolidation::main_impl() {
                   fromNotes.push_back(saplingEntry);
                 }
 
-                //Only use a randomly determined number of notes between 10 and 45
+                //Only use a randomly determined number of notes
                 if (fromNotes.size() >= maxQuantity)
                   break;
 
             }
 
-            //random minimum 2 - 12 required
-            int minQuantity = rand() % 10 + 2;
+            // minimum required
+            // We use 3 so that addresses can spent one zutxo and still have another zutxo to use while that
+            // tx is confirming
+            int minQuantity = 3;
             if (fromNotes.size() < minQuantity)
               continue;
 

--- a/src/wallet/asyncrpcoperation_saplingconsolidation.cpp
+++ b/src/wallet/asyncrpcoperation_saplingconsolidation.cpp
@@ -16,7 +16,6 @@
 #include "util.h"
 #include "utilmoneystr.h"
 #include "wallet.h"
-//#include "sietch.h"
 
 CAmount fConsolidationTxFee = DEFAULT_CONSOLIDATION_FEE;
 bool fConsolidationMapUsed = false;

--- a/src/wallet/asyncrpcoperation_saplingconsolidation.h
+++ b/src/wallet/asyncrpcoperation_saplingconsolidation.h
@@ -1,11 +1,16 @@
+// Copyright (c) 2020 The Hush developers
+// TODO: Forge should add his preferred copyright line here
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "amount.h"
 #include "asyncrpcoperation.h"
 #include "univalue.h"
 #include "zcash/Address.hpp"
 #include "zcash/zip32.h"
 
-//Default fee used for consolidation transactions
-static const CAmount DEFAULT_CONSOLIDATION_FEE = 0;
+//Default fee used for consolidation transactions, in puposhis
+static const CAmount DEFAULT_CONSOLIDATION_FEE = 10000;
 extern CAmount fConsolidationTxFee;
 extern bool fConsolidationMapUsed;
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -62,7 +62,7 @@
 
 #include "komodo_defs.h"
 #include <string.h>
-#include "sietch.h"
+//#include "sietch.h"
 #include "rpchushwallet.h"
 
 using namespace std;
@@ -79,6 +79,7 @@ uint32_t komodo_segid32(char *coinaddr);
 int32_t komodo_dpowconfs(int32_t height,int32_t numconfs);
 int32_t komodo_isnotaryvout(char *coinaddr,uint32_t tiptime); // from ac_private chains only
 CBlockIndex *komodo_getblockindex(uint256 hash);
+extern string randomSietchZaddr();
 
 int64_t nWalletUnlockTime;
 static CCriticalSection cs_nWalletUnlockTime;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -62,7 +62,6 @@
 
 #include "komodo_defs.h"
 #include <string.h>
-//#include "sietch.h"
 #include "rpchushwallet.h"
 
 using namespace std;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -42,6 +42,7 @@
 #include "zcash/Address.hpp"
 #include "zcash/zip32.h"
 #include "base58.h"
+//#include "sietch.h"
 
 #include <algorithm>
 #include <map>

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
-// Copyright (c) 2019      The Hush developers
+// Copyright (c) 2019-2020 The Hush developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -42,7 +42,6 @@
 #include "zcash/Address.hpp"
 #include "zcash/zip32.h"
 #include "base58.h"
-//#include "sietch.h"
 
 #include <algorithm>
 #include <map>


### PR DESCRIPTION
@DenioD can you give this a test? If you do, post an explorer link here for a sapcon tx it makes.

We should see all sapcon ztx's created with this code have exactly 8 zouts, which blends in currently with the most common number of zouts z_sendmany creates for average ztxs.

Additionally, this code reduces anonset reduction by 7 per transaction and obscures the amounts going to any one zout.