### PR TITLE
fix dead openssl download path

### DIFF
--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -1,6 +1,6 @@
 package=openssl
 $(package)_version=1.1.1a
-$(package)_download_path=https://www.openssl.org/source
+$(package)_download_path=https://www.openssl.org/source/old/1.1.1
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=fc20130f8b7cbd2fb918b2f14e2f429e109c31ddd0fb38fc5d71d9ffed3f9f41
 $(package)_patches=ssl_fix.patch


### PR DESCRIPTION
updates openssl 1.1.1a download path analogue to https://github.com/komodoplatform/komodo/commit/318ec36218774d0f01b0220f7cbcadbe4c44c408

fyi: we are testing 1.1.1f in https://github.com/KomodoPlatform/komodo/pull/314