### PR TITLE
Ignore amount=0 zutxos in GetFilteredNotes() by default

### DIFF
--- a/src/wallet/asyncrpcoperation_saplingconsolidation.cpp
+++ b/src/wallet/asyncrpcoperation_saplingconsolidation.cpp
@@ -95,7 +95,12 @@ bool AsyncRPCOperation_saplingconsolidation::main_impl() {
         // We set minDepth to 11 to avoid unconfirmed notes and in anticipation of specifying
         // an anchor at height N-10 for each Sprout JoinSplit description
         // Consider, should notes be sorted?
-        pwalletMain->GetFilteredNotes(sproutEntries, saplingEntries, "", 11);
+        bool ignoreSpent=true;
+        bool requireSpendingKey=true;
+        bool ignoreLocked=true;
+        bool ignoreZeroValue=false;
+
+        pwalletMain->GetFilteredNotes(sproutEntries, saplingEntries, "", 11, ignoreSpent, requireSpendingKey, ignoreLocked, ignoreZeroValue);
         if (fConsolidationMapUsed) {
             const vector<string>& v = mapMultiArgs["-consolidatesaplingaddress"];
             for(int i = 0; i < v.size(); i++) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1372,7 +1372,9 @@ public:
                           std::string address,
                           int minDepth=1,
                           bool ignoreSpent=true,
-                          bool requireSpendingKey=true);
+                          bool requireSpendingKey=true,
+                          bool ignoreLocked=true,
+                          bool ignoreZeroValue=true);
 
     /* Find notes filtered by payment addresses, min depth, max depth, if they are spent,
        if a spending key is required, and if they are locked */
@@ -1383,7 +1385,8 @@ public:
                           int maxDepth=INT_MAX,
                           bool ignoreSpent=true,
                           bool requireSpendingKey=true,
-                          bool ignoreLocked=true);
+                          bool ignoreLocked=true,
+                          bool ignoreZeroValue=true);
 
 };
 


### PR DESCRIPTION
This needs testing. It implements the good idea from https://github.com/zcash/zcash/issues/4429 to ignore amount=0 zutxos unless they are explicitly asked for. Currently the only codepath which explicitly asks for them is Sapling Consolidation, since it can automatically clean up after zdust attacks. Since Hush and HushChat use amount=0 extensively, this optimization should be noticeable. Additionally, it gives users an automatic feature to clean up after shielded spam attacks while never reducing the anonymity set, since Sietch was added to Sapling Consolidation in our codebase.

This is not a consensus change, but it is a backward incompatible change, purposefully. Previously, `z_listunspent` would return all amount=0 zutxos, by historical accident. No consumer of this data ever uses amount=0 zutxos. So we can add a flag to that RPC and others if there is a use case for amount=0 zutxos. This should greatly reduce the amount of data exchanged by GUI wallet and full node and reduces the amount of JSON to parse.

We need to make sure there is no unintended consequences of this, for instance, `listtransactions` should still return amount=0 notes but may need to learn about the new options to `GetFilteredNotes()`